### PR TITLE
Feature/add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# 使用幸狐官方提供的 Luckfox Pico 镜像作为基础
+FROM luckfoxtech/luckfox_pico:1.0
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list && \
+    sed -i 's/security.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    git \
+    ninja-build \
+    pkg-config \
+    libjson-c-dev \
+    libjsoncpp-dev \
+    libcurl4-openssl-dev \
+    libwebsocketpp-dev \
+    libboost-all-dev \
+    libopus-dev \
+    portaudio19-dev \
+    libdrm-dev \
+    libsdl2-dev \
+    libsdl2-image-dev \
+    libopenblas-dev \
+    x11-apps \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# 创建一个工作目录
+WORKDIR /project
+
+# 容器启动时默认执行的命令
+CMD ["/bin/bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  rv1106-dev:
+    container_name: echo-mate
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      # 将当前目录下的所有文件挂载到容器的 /project 目录
+      - .:/project
+      # 挂载sdk目录，需要根据自己的sdk目录进行调整
+      - /home/hao/projects/luckfox-pico:/sdk
+      # 挂载 X11 socket，实现 GUI 转发
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    # 环境变量
+    environment:
+      - DISPLAY=${DISPLAY}
+
+    network_mode: "host"
+    stdin_open: true
+    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     environment:
       - DISPLAY=${DISPLAY}
 
+    # 开启特权模式，编译sdk需要
+    privileged: true
     network_mode: "host"
     stdin_open: true
     tty: true


### PR DESCRIPTION
**开发者你好：**

我在 Fedora 系统上搭建本项目环境，与教程推荐的 Ubuntu 22.04 存在一些环境差异，配置过程较为不便。因此，我基于幸狐官方提供的 Docker 镜像（该镜像基于 Ubuntu 22.04），额外添加了 LVGL 仿真所需的本地库。同时，通过挂载本地 SDK 目录的方式，也完整支持了对原项目的交叉编译开发。本次改动是非侵入性的，仅添加了两个docker相关的配置文件，这样做可以方便其他开发者快速上手，后续我会创建一个issue来说明具体如何使用，希望能接纳我的提交。