### PR TITLE
修复阿里云百炼 API Key 截断导致 LLM 调用 401

### DIFF
--- a/DeskBot_demo/common/sys_manager/sys_manager.h
+++ b/DeskBot_demo/common/sys_manager/sys_manager.h
@@ -22,7 +22,7 @@ typedef struct {
     int port;
     char token[20];
     char device_id[20];
-    char aliyun_api_key[36];        // 阿里百炼 api key for deepseek (need store)
+    char aliyun_api_key[128];       // 阿里百炼 api key for deepseek (need store)
     int protocol_version;
     int sample_rate;
     int channels;


### PR DESCRIPTION
阿里云百炼在 2026-06-26 后更换了 API Key 格式，新 key 长度超过 80 字节，而 DeskBot_demo 中 `aliyun_api_key` 缓冲区只有 36 字节，导致写入配置时 key 被静默截断。客户端通过 hello 消息将截断后的无效 key 发送给服务器，覆盖了服务端配置中的有效 key，最终导致所有 LLM 请求返回 401 Unauthorized。

将缓冲区从 36 字节扩大到 128 字节，完整存储新格式的 API Key。

Fix #9 